### PR TITLE
Added missing file '98-spidev.rules'

### DIFF
--- a/PlatformWithOS/driver-common/98-spidev.rules
+++ b/PlatformWithOS/driver-common/98-spidev.rules
@@ -1,0 +1,2 @@
+KERNEL=="spidev0.0", SUBSYSTEM=="spidev", TAG+="systemd"
+


### PR DESCRIPTION
Added missing '98-spidev.rules' file to install succesfully with `sudo make rpi-install`.

In gratis2 repository, is missing the file PlatformWithOS'/driver-common/98-spidev.rules' that the makefile try to install.
![sudo make rpi-install](https://user-images.githubusercontent.com/8146845/94172181-8df63c00-fe68-11ea-831f-104358487dcf.png)

After adding it:
![after correction](https://user-images.githubusercontent.com/8146845/94172244-a403fc80-fe68-11ea-8cd3-a1f503e4c654.png)

